### PR TITLE
(fix): Consistent input/output test cutouts bbox

### DIFF
--- a/deepem/test/option.py
+++ b/deepem/test/option.py
@@ -66,6 +66,7 @@ class Options(object):
         self.parser.add_argument('--gs_input_norm', type=float, default=None, nargs='+')
         self.parser.add_argument('--in_mip', type=int, default=0)
         self.parser.add_argument('--cache', action='store_true')
+        self.parser.add_argument('--coord_mip', type=int, default=0)
         self.parser.add_argument('-b','--begin', type=vec3, default=None)
         self.parser.add_argument('-e','--end', type=vec3, default=None)
         self.parser.add_argument('-c','--center', type=vec3, default=None)


### PR DESCRIPTION
Rely on CloudVolume to guarantee input and output bboxes are consistent for tests. MIP hierarchies are not guaranteed to be powers of 2 (especially with float resolutions), so need to use the info file and be consistent computing the offset between input and output.