### PR TITLE
Replace DP with DDP

### DIFF
--- a/deepem/train/data.py
+++ b/deepem/train/data.py
@@ -28,8 +28,8 @@ class Dataset(torch.utils.data.Dataset):
 
 
 class Data(object):
-    def __init__(self, opt, data, is_train=True, prob=None):
-        self.build(opt, data, is_train, prob)
+    def __init__(self, opt, data, is_train=True, prob=None, local_rank=None):
+        self.build(opt, data, is_train, prob, local_rank)
 
     def __call__(self):
         sample = next(self.dataiter)
@@ -37,13 +37,13 @@ class Data(object):
         for k in sample:
             is_input = k in self.inputs
             sample[k].requires_grad_(is_input)
-            sample[k] = sample[k].cuda(non_blocking=(not is_input))
+            sample[k] = sample[k].cuda(device=self.local_rank, non_blocking=(not is_input))
         return sample
 
     def requires_grad(self, key):
         return self.is_train and (key in self.inputs)
 
-    def build(self, opt, data, is_train, prob):
+    def build(self, opt, data, is_train, prob, local_rank):
         # Data augmentation
         if opt.augment:
             mod = load_module('augment', opt.augment)
@@ -79,3 +79,4 @@ class Data(object):
         self.dataiter = iter(dataloader)
         self.inputs = opt.in_spec.keys()
         self.is_train = is_train
+        self.local_rank = local_rank

--- a/deepem/train/logger.py
+++ b/deepem/train/logger.py
@@ -4,6 +4,7 @@ import datetime
 from collections import OrderedDict
 
 import torch
+import torch.distributed as dist
 
 
 class Logger(object):
@@ -20,12 +21,16 @@ class Logger(object):
 
         # Basic logging
         self.timestamp = datetime.datetime.now().strftime("%y%m%d_%H%M%S")
+        self.blv_num_channels = opt.blv_num_channels
+
+        if opt.parallel == "DDP" and dist.get_rank() > 0:
+            return
+
         self.log_params(vars(opt))
         self.log_command()
         self.log_command_args()
 
         # Blood vessel
-        self.blv_num_channels = opt.blv_num_channels
 
     def __enter__(self):
         return self

--- a/deepem/train/model.py
+++ b/deepem/train/model.py
@@ -53,8 +53,8 @@ class Model(nn.Module):
             nmasks[k] = nmsk.unsqueeze(0)
         return losses, nmasks
 
-    def state_dict(self):
-        return self.model.state_dict()
+    def state_dict(self, destination={}, prefix="", keep_vars=False):
+        return self.model.state_dict(destination, prefix, keep_vars)
 
     def save(self, fpath):
         torch.save(self.model.state_dict(), fpath)

--- a/deepem/train/option.py
+++ b/deepem/train/option.py
@@ -185,12 +185,18 @@ class Options(object):
         self.parser.add_argument('--export_onnx', action='store_true')
         self.parser.add_argument('--opset_version', type=int, default=10)
 
+        self.parser.add_argument('--parallel', type=str, choices=["DDP", "DP", ], default=None)
+
         self.initialized = True
 
     def parse(self):
         if not self.initialized:
             self.initialize()
         opt = self.parser.parse_args()
+
+        if not opt.parallel:
+            if "RANK" in os.environ or "LOCAL_RANK" in os.environ:
+                opt.parallel = "DDP"
 
         # Directories
         if opt.exp_name.split('/')[0] == 'experiments':

--- a/deepem/train/run.py
+++ b/deepem/train/run.py
@@ -25,7 +25,7 @@ def cleanup_distributed():
 
 def train(opt):
     # Model
-    local_rank = dist.get_rank() % torch.cuda.device_count()  # Identify which GPU to use
+    local_rank = int(os.environ["LOCAL_RANK"])
     torch.cuda.set_device(local_rank)
     model = load_model(opt)
     model = model.cuda(local_rank)  # Move model to the corresponding GPU

--- a/deepem/train/run.py
+++ b/deepem/train/run.py
@@ -2,6 +2,9 @@ import os
 import time
 
 import torch
+import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel as DDP
+
 import samwise
 
 from deepem.train.logger import Logger
@@ -12,9 +15,21 @@ from deepem.train.utils import *
 from deepem.utils.onnx_utils import export_onnx
 
 
+def setup_distributed(backend='nccl'):
+    dist.init_process_group(backend=backend)
+
+
+def cleanup_distributed():
+    dist.destroy_process_group()
+
+
 def train(opt):
     # Model
+    local_rank = dist.get_rank() % torch.cuda.device_count()  # Identify which GPU to use
+    torch.cuda.set_device(local_rank)
     model = load_model(opt)
+    model = model.cuda(local_rank)  # Move model to the corresponding GPU
+    model = DDP(model, device_ids=[local_rank])  # Wrap model with DDP
 
     # Optimizer
     trainable = filter(lambda p: p.requires_grad, model.parameters())
@@ -132,6 +147,7 @@ def eval_loop(iter_num, model, data_loader, opt, logger, wandb_logger):
 
 
 if __name__ == "__main__":
+    setup_distributed()
 
     # Options
     opt = Options().parse()
@@ -160,3 +176,5 @@ if __name__ == "__main__":
             train(opt)
 
         samwise.run(f, opt.samwise_map, period=opt.samwise_period)
+
+    cleanup_distributed()

--- a/deepem/train/run.py
+++ b/deepem/train/run.py
@@ -25,11 +25,17 @@ def cleanup_distributed():
 
 def train(opt):
     # Model
-    local_rank = int(os.environ["LOCAL_RANK"])
-    torch.cuda.set_device(local_rank)
-    model = load_model(opt)
-    model = model.cuda(local_rank)  # Move model to the corresponding GPU
-    model = DDP(model, device_ids=[local_rank])  # Wrap model with DDP
+    if opt.parallel == "DDP":
+        # Make sure samewise finished syncing files
+        dist.barrier()
+        local_rank = int(os.environ["LOCAL_RANK"])
+        torch.cuda.set_device(local_rank)
+        model = load_model(opt)
+        model = model.cuda(local_rank)  # Move model to the corresponding GPU
+        model = DDP(model, device_ids=[local_rank])  # Wrap model with DDP
+    else:
+        local_rank = None
+        model = load_model(opt)
 
     # Optimizer
     trainable = filter(lambda p: p.requires_grad, model.parameters())
@@ -39,7 +45,7 @@ def train(opt):
     train_loader, val_loader = load_data(opt, local_rank)
 
     # Initial checkpoint
-    if dist.get_rank() == 0:
+    if opt.parallel != "DDP" or dist.get_rank() == 0:
         save_chkpt(model, opt.model_dir, opt.chkpt_num, optimizer)
 
     # Mixed-precision training
@@ -97,11 +103,12 @@ def train(opt):
 
             # Evaluation loop
             if (i+1) % opt.eval_intv == 0:
-                eval_loop(i+1, model, val_loader, opt, logger, wandb_logger)
+                if opt.parallel != "DDP" or dist.get_rank() == 0:
+                    eval_loop(i+1, model, val_loader, opt, logger, wandb_logger)
 
             # Model checkpoint
             if (i+1) % opt.chkpt_intv == 0:
-                if dist.get_rank() == 0:
+                if opt.parallel != "DDP" or dist.get_rank() == 0:
                     save_chkpt(model, opt.model_dir, i+1, optimizer)
                     if opt.export_onnx:
                         export_onnx(opt, i+1)
@@ -149,16 +156,17 @@ def eval_loop(iter_num, model, data_loader, opt, logger, wandb_logger):
 
 
 if __name__ == "__main__":
-    setup_distributed()
 
     # Options
     opt = Options().parse()
 
+    if opt.parallel == "DDP":
+        setup_distributed()
     # GPUs
     os.environ['CUDA_VISIBLE_DEVICES'] = ','.join(opt.gpu_ids)
 
     # Make directories.
-    if dist.get_rank() == 0:
+    if opt.parallel == "DDP" and dist.get_rank() == 0:
         if not os.path.isdir(opt.exp_dir):
             os.makedirs(opt.exp_dir)
         if not os.path.isdir(opt.log_dir):
@@ -173,11 +181,14 @@ if __name__ == "__main__":
     print(f"Running experiment: {opt.exp_name}")
     if opt.samwise_map is None:
         train(opt)
-
-    else:
+    elif opt.parallel != "DDP" or dist.get_rank() == 0:
         def f():
             train(opt)
-
         samwise.run(f, opt.samwise_map, period=opt.samwise_period)
+    else:
+        if dist.get_rank() % len(opt.gpu_ids) == 0:
+            samwise.storage.initdirs(opt.samwise_map)
+        train(opt)
 
-    cleanup_distributed()
+    if opt.parallel == "DDP":
+        cleanup_distributed()

--- a/deepem/train/run.py
+++ b/deepem/train/run.py
@@ -36,7 +36,7 @@ def train(opt):
     optimizer = load_optimizer(opt, trainable)
 
     # Data loaders
-    train_loader, val_loader = load_data(opt)
+    train_loader, val_loader = load_data(opt, local_rank)
 
     # Initial checkpoint
     if dist.get_rank() == 0:

--- a/deepem/train/run.py
+++ b/deepem/train/run.py
@@ -39,7 +39,8 @@ def train(opt):
     train_loader, val_loader = load_data(opt)
 
     # Initial checkpoint
-    save_chkpt(model, opt.model_dir, opt.chkpt_num, optimizer)
+    if dist.get_rank() == 0:
+        save_chkpt(model, opt.model_dir, opt.chkpt_num, optimizer)
 
     # Mixed-precision training
     if opt.mixed_precision:
@@ -100,9 +101,10 @@ def train(opt):
 
             # Model checkpoint
             if (i+1) % opt.chkpt_intv == 0:
-                save_chkpt(model, opt.model_dir, i+1, optimizer)
-                if opt.export_onnx:
-                    export_onnx(opt, i+1)
+                if dist.get_rank() == 0:
+                    save_chkpt(model, opt.model_dir, i+1, optimizer)
+                    if opt.export_onnx:
+                        export_onnx(opt, i+1)
 
             # Reset timer.
             t0 = time.time()
@@ -156,12 +158,13 @@ if __name__ == "__main__":
     os.environ['CUDA_VISIBLE_DEVICES'] = ','.join(opt.gpu_ids)
 
     # Make directories.
-    if not os.path.isdir(opt.exp_dir):
-        os.makedirs(opt.exp_dir)
-    if not os.path.isdir(opt.log_dir):
-        os.makedirs(opt.log_dir)
-    if not os.path.isdir(opt.model_dir):
-        os.makedirs(opt.model_dir)
+    if dist.get_rank() == 0:
+        if not os.path.isdir(opt.exp_dir):
+            os.makedirs(opt.exp_dir)
+        if not os.path.isdir(opt.log_dir):
+            os.makedirs(opt.log_dir)
+        if not os.path.isdir(opt.model_dir):
+            os.makedirs(opt.model_dir)
 
     # cuDNN auto-tuning
     torch.backends.cudnn.benchmark = not opt.no_autotune

--- a/deepem/train/run.py
+++ b/deepem/train/run.py
@@ -13,6 +13,7 @@ from deepem.train.option import Options
 from deepem.train.utils import *
 
 from deepem.utils.onnx_utils import export_onnx
+from deepem.utils.torch_utils import revert_sync_batchnorm
 
 
 def setup_distributed(backend='nccl'):
@@ -31,6 +32,7 @@ def train(opt):
         local_rank = int(os.environ["LOCAL_RANK"])
         torch.cuda.set_device(local_rank)
         model = load_model(opt)
+        model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
         model = model.cuda(local_rank)  # Move model to the corresponding GPU
         model = DDP(model, device_ids=[local_rank])  # Wrap model with DDP
     else:
@@ -45,7 +47,12 @@ def train(opt):
     train_loader, val_loader = load_data(opt, local_rank)
 
     # Initial checkpoint
-    if opt.parallel != "DDP" or dist.get_rank() == 0:
+    if opt.parallel == "DDP":
+        if dist.get_rank() == 0:
+            model = revert_sync_batchnorm(model)
+            save_chkpt(model, opt.model_dir, opt.chkpt_num, optimizer)
+            model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+    else:
         save_chkpt(model, opt.model_dir, opt.chkpt_num, optimizer)
 
     # Mixed-precision training
@@ -103,12 +110,24 @@ def train(opt):
 
             # Evaluation loop
             if (i+1) % opt.eval_intv == 0:
-                if opt.parallel != "DDP" or dist.get_rank() == 0:
+                if opt.parallel == "DDP":
+                    if dist.get_rank() == 0:
+                        model = revert_sync_batchnorm(model)
+                        eval_loop(i+1, model, val_loader, opt, logger, wandb_logger)
+                        model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+                else:
                     eval_loop(i+1, model, val_loader, opt, logger, wandb_logger)
 
             # Model checkpoint
             if (i+1) % opt.chkpt_intv == 0:
-                if opt.parallel != "DDP" or dist.get_rank() == 0:
+                if opt.parallel == "DDP":
+                    if dist.get_rank() == 0:
+                        model = revert_sync_batchnorm(model)
+                        save_chkpt(model, opt.model_dir, i+1, optimizer)
+                        if opt.export_onnx:
+                            export_onnx(opt, i+1)
+                        model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+                else:
                     save_chkpt(model, opt.model_dir, i+1, optimizer)
                     if opt.export_onnx:
                         export_onnx(opt, i+1)

--- a/deepem/train/run.py
+++ b/deepem/train/run.py
@@ -50,7 +50,7 @@ def train(opt):
     if opt.parallel == "DDP":
         if dist.get_rank() == 0:
             model = revert_sync_batchnorm(model)
-            save_chkpt(model, opt.model_dir, opt.chkpt_num, optimizer)
+            save_chkpt(model.module, opt.model_dir, opt.chkpt_num, optimizer)
             model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
     else:
         save_chkpt(model, opt.model_dir, opt.chkpt_num, optimizer)
@@ -123,7 +123,7 @@ def train(opt):
                 if opt.parallel == "DDP":
                     if dist.get_rank() == 0:
                         model = revert_sync_batchnorm(model)
-                        save_chkpt(model, opt.model_dir, i+1, optimizer)
+                        save_chkpt(model.module, opt.model_dir, i+1, optimizer)
                         if opt.export_onnx:
                             export_onnx(opt, i+1)
                         model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)

--- a/deepem/train/utils.py
+++ b/deepem/train/utils.py
@@ -166,7 +166,7 @@ def load_data(opt, local_rank):
 
 def forward(model, sample, opt):
     # Forward pass
-    if len(opt.gpu_ids) > 1:
+    if len(opt.gpu_ids) > 1 and opt.parallel == 'DP':
         losses, nmasks, preds = data_parallel(model, sample)
     else:
         losses, nmasks, preds = model(sample)

--- a/deepem/train/utils.py
+++ b/deepem/train/utils.py
@@ -133,7 +133,7 @@ def save_chkpt(model, fpath, chkpt_num, optimizer):
     torch.save(state, fname)
 
 
-def load_data(opt):
+def load_data(opt, local_rank):
     data_ids = list(set().union(opt.train_ids, opt.val_ids))
     if opt.zettaset_specs:
         from deepem.data.dataset import multi_zettaset as mod
@@ -151,7 +151,7 @@ def load_data(opt):
         prob = dict(zip(opt.train_ids, opt.train_prob))
     else:
         prob = None
-    train_loader = Data(opt, train_data, is_train=True, prob=prob)
+    train_loader = Data(opt, train_data, is_train=True, prob=prob, local_rank=local_rank)
 
     # Validation
     val_data = {k: data[k] for k in opt.val_ids}
@@ -159,7 +159,7 @@ def load_data(opt):
         prob = dict(zip(opt.val_ids, opt.val_prob))
     else:
         prob = None
-    val_loader = Data(opt, val_data, is_train=False, prob=prob)
+    val_loader = Data(opt, val_data, is_train=False, prob=prob, local_rank=local_rank)
 
     return train_loader, val_loader
 

--- a/deepem/train/wandb_logger.py
+++ b/deepem/train/wandb_logger.py
@@ -6,6 +6,7 @@ from types import TracebackType
 
 import numpy as np
 import torch
+import torch.distributed as dist
 from torchvision.utils import make_grid
 import wandb
 
@@ -22,6 +23,8 @@ class WandbLogger:
         self,
         opt: argparse.Namespace,
     ):
+        if dist.get_rank() > 0:
+            return
         self.opt = opt
         self.in_spec = dict(opt.in_spec)
         self.out_spec = dict(opt.out_spec)
@@ -57,6 +60,8 @@ class WandbLogger:
         iter_num: int,
         stats: dict[str, float],
     ) -> None:
+        if dist.get_rank() > 0:
+            return
         wandb.log(
             {f"{phase}/{metric}": value for metric, value in stats.items()},
             step=iter_num
@@ -69,6 +74,8 @@ class WandbLogger:
         sample: dict[str, torch.Tensor],
     ) -> None:
         """Log 3D images."""
+        if dist.get_rank() > 0:
+            return
         # Get reference sizes
         out_key = sorted(self.out_spec)[0]
         in_key = sorted(self.in_spec)[0]

--- a/deepem/train/wandb_logger.py
+++ b/deepem/train/wandb_logger.py
@@ -23,8 +23,6 @@ class WandbLogger:
         self,
         opt: argparse.Namespace,
     ):
-        if dist.get_rank() > 0:
-            return
         self.opt = opt
         self.in_spec = dict(opt.in_spec)
         self.out_spec = dict(opt.out_spec)
@@ -60,7 +58,7 @@ class WandbLogger:
         iter_num: int,
         stats: dict[str, float],
     ) -> None:
-        if dist.get_rank() > 0:
+        if self.opt.parallel == "DDP" and dist.get_rank() > 0:
             return
         wandb.log(
             {f"{phase}/{metric}": value for metric, value in stats.items()},
@@ -74,7 +72,7 @@ class WandbLogger:
         sample: dict[str, torch.Tensor],
     ) -> None:
         """Log 3D images."""
-        if dist.get_rank() > 0:
+        if self.opt.parallel == "DDP" and dist.get_rank() > 0:
             return
         # Get reference sizes
         out_key = sorted(self.out_spec)[0]

--- a/deepem/utils/torch_utils.py
+++ b/deepem/utils/torch_utils.py
@@ -7,6 +7,30 @@ from torch.nn import functional as F
 from deepem.utils import py_utils
 
 
+def revert_sync_batchnorm(module):
+    # this is very similar to the function that it is trying to revert:
+    # https://github.com/pytorch/pytorch/blob/c8b3686a3e4ba63dc59e5dcfe5db3430df256833/torch/nn/modules/batchnorm.py#L679
+    module_output = module
+    if isinstance(module, nn.modules.batchnorm.SyncBatchNorm):
+        module_output = nn.BatchNorm3d(module.num_features,
+                                               module.eps, module.momentum,
+                                               module.affine,
+                                               module.track_running_stats)
+        if module.affine:
+            with torch.no_grad():
+                module_output.weight = module.weight
+                module_output.bias = module.bias
+        module_output.running_mean = module.running_mean
+        module_output.running_var = module.running_var
+        module_output.num_batches_tracked = module.num_batches_tracked
+        if hasattr(module, "qconfig"):
+            module_output.qconfig = module.qconfig
+    for name, child in module.named_children():
+        module_output.add_module(name, revert_sync_batchnorm(child))
+    del module
+    return module_output
+
+
 def get_pair_first(arr, edge):
     shape = arr.size()[-3:]
     edge = np.array(edge)

--- a/docker/zettasets/Dockerfile
+++ b/docker/zettasets/Dockerfile
@@ -35,7 +35,7 @@ RUN conda install -y h5py cython matplotlib scikit-image scikit-learn && \
 # Explicitly pin NumPy to <2 to avoid ABI issues
 RUN pip install --no-cache-dir --upgrade \
         "numpy<2" cloud-volume task-queue imgaug wandb \
-        cffi brotli fastremap imagecodecs onnx
+        cffi brotli fastremap imagecodecs python-etcd onnx
 
 RUN pip install --no-cache-dir \
         git+https://github.com/seung-lab/DataTools && \

--- a/docker/zettasets/Dockerfile
+++ b/docker/zettasets/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update --allow-releaseinfo-change && \
 
 # Use an optimized PyTorch base image
 # FROM pytorch/pytorch:1.11.0-cuda11.3-cudnn8-runtime
-FROM pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime
+FROM pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker/zettasets/Dockerfile
+++ b/docker/zettasets/Dockerfile
@@ -59,5 +59,3 @@ ENV PYTHONPATH=/DeepEM:${PYTHONPATH}
 
 COPY . /DeepEM/
 WORKDIR /workspace
-
-ENTRYPOINT ["python", "/DeepEM/deepem/train/run.py"]


### PR DESCRIPTION
DDP suppose to have less overhead comparing to DP, this PR adds basic support for DDP to replace DP, it relies on `torchrun` to launch multiple instances and setup match DDP variables. So instead of `python deepem/train/run.py` the training should be launch with something like `torchrun --nnodes=1 --nproc_per_node=8 --node_rank=0 --master_addr="localhost" --master_port=12345 deepem/train/run.py... ` The meaning of `batch_size` and `num_workers` changed to batch_size per proc, and num_workers per proc. I think they are more sensible this way and generalize to the situation when training on a cluster where instances join and leave.