### PR TITLE
Refactor multi-input models to use dictionaries instead of concatenated tensors

### DIFF
--- a/deepem/models/rsunet_multi_io.py
+++ b/deepem/models/rsunet_multi_io.py
@@ -19,13 +19,21 @@ def create_model(opt):
 
 
 class InputBlock(nn.Module):
-    def __init__(self, in_spec, out_channels, kernel_size):
+    def __init__(self, in_spec, out_channels, kernel_size, onnx=False):
         super().__init__()
-        total_in_channels = sum(v[-4] for v in in_spec.values())
-        self.block = Conv(total_in_channels, out_channels, kernel_size)
+        self.onnx = onnx
+        self.keys = sorted(in_spec.keys())  # Store keys for ONNX mode
+        self.blocks = nn.ModuleDict({
+            k: Conv(v[-4], out_channels, kernel_size)
+            for k, v in in_spec.items()
+        })
 
     def forward(self, x):
-        return self.block(x)
+        if self.onnx:
+            # For ONNX, expect x to be a tuple of tensors in same order as self.keys
+            return sum(self.blocks[k](xi) for k, xi in zip(self.keys, x))
+        # Normal PyTorch mode - x is a dict
+        return sum(m(x[k]) for k, m in self.blocks.items())
 
 
 class OutputBlock(nn.Module):
@@ -54,7 +62,7 @@ class Model(nn.Sequential):
     def __init__(self, core, in_spec, out_spec, out_channels, io_kernel=(1, 5, 5),
                  crop=None, onnx=False, scale_init=1.0):
         super().__init__()
-        self.add_module('in', InputBlock(in_spec, out_channels, io_kernel))
+        self.add_module('in', InputBlock(in_spec, out_channels, io_kernel, onnx))
         self.add_module('core', core)
         self.add_module('out',
             OutputBlock(out_channels, out_spec, io_kernel, onnx=onnx, scale_init=scale_init))

--- a/deepem/models/rsunet_multi_io_iso.py
+++ b/deepem/models/rsunet_multi_io_iso.py
@@ -20,13 +20,21 @@ def create_model(opt):
 
 
 class InputBlock(nn.Module):
-    def __init__(self, in_spec, out_channels, kernel_size):
+    def __init__(self, in_spec, out_channels, kernel_size, onnx=False):
         super().__init__()
-        total_in_channels = sum(v[-4] for v in in_spec.values())
-        self.block = Conv(total_in_channels, out_channels, kernel_size)
+        self.onnx = onnx
+        self.keys = sorted(in_spec.keys())  # Store keys for ONNX mode
+        self.blocks = nn.ModuleDict({
+            k: Conv(v[-4], out_channels, kernel_size)
+            for k, v in in_spec.items()
+        })
 
     def forward(self, x):
-        return self.block(x)
+        if self.onnx:
+            # For ONNX, expect x to be a tuple of tensors in same order as self.keys
+            return sum(self.blocks[k](xi) for k, xi in zip(self.keys, x))
+        # Normal PyTorch mode - x is a dict
+        return sum(m(x[k]) for k, m in self.blocks.items())
 
 
 class OutputBlock(nn.Module):
@@ -55,7 +63,7 @@ class Model(nn.Sequential):
     def __init__(self, core, in_spec, out_spec, out_channels, io_kernel=(5, 5, 5),
                  crop=None, onnx=False, scale_init=1.0):
         super().__init__()
-        self.add_module('in', InputBlock(in_spec, out_channels, io_kernel))
+        self.add_module('in', InputBlock(in_spec, out_channels, io_kernel, onnx=onnx))
         self.add_module('core', core)
         self.add_module('out',
             OutputBlock(out_channels, out_spec, io_kernel, onnx=onnx, scale_init=scale_init))

--- a/deepem/models/updown_multi_io_iso_interpolate.py
+++ b/deepem/models/updown_multi_io_iso_interpolate.py
@@ -15,18 +15,26 @@ def create_model(opt):
     else:
         # Batch normalization
         core = rsunet_act(width=width[:depth], zfactor=zfactor, act=opt.act)
-    return Model(core, opt.in_spec, opt.out_spec, width[0], crop=opt.crop,
+    return Model(core, opt.in_spec, opt.out_spec, width[0], crop=opt.crop, onnx=opt.onnx,
                 scale_init=opt.scale_init, scale_factor=opt.updown_scale_factor)
 
 
 class InputBlock(nn.Module):
-    def __init__(self, in_spec, out_channels, kernel_size):
+    def __init__(self, in_spec, out_channels, kernel_size, onnx=False):
         super().__init__()
-        total_in_channels = sum(v[-4] for v in in_spec.values())
-        self.block = Conv(total_in_channels, out_channels, kernel_size)
+        self.onnx = onnx
+        self.keys = sorted(in_spec.keys())  # Store keys for ONNX mode
+        self.blocks = nn.ModuleDict({
+            k: Conv(v[-4], out_channels, kernel_size)
+            for k, v in in_spec.items()
+        })
 
     def forward(self, x):
-        return self.block(x)
+        if self.onnx:
+            # For ONNX, expect x to be a tuple of tensors in same order as self.keys
+            return sum(self.blocks[k](xi) for k, xi in zip(self.keys, x))
+        # Normal PyTorch mode - x is a dict
+        return sum(m(x[k]) for k, m in self.blocks.items())
 
 
 class OutputBlock(nn.Module):
@@ -77,7 +85,7 @@ class Model(nn.Sequential):
     Residual Symmetric U-Net with down/upsampling for multiple inputs/outputs.
     """
     def __init__(self, core, in_spec, out_spec, out_channels, io_kernel=(5, 5, 5),
-                crop=None, scale_init=1.0, scale_factor=(1, 2, 2)):
+                crop=None, scale_init=1.0, scale_factor=(1, 2, 2), onnx=False):
         super().__init__()
 
         in_size = next(iter(in_spec.values()))[-3:]
@@ -88,9 +96,9 @@ class Model(nn.Sequential):
         new_size = tuple(int(s / f) for s, f in zip(in_size, scale_factor))
 
         self.add_module('down', DownBlock(size=new_size))
-        self.add_module('in', InputBlock(in_spec, out_channels, io_kernel))
+        self.add_module('in', InputBlock(in_spec, out_channels, io_kernel, onnx=onnx))
         self.add_module('core', core)
-        self.add_module('out', OutputBlock(out_channels, out_spec, io_kernel, scale_init=scale_init))
+        self.add_module('out', OutputBlock(out_channels, out_spec, io_kernel, onnx=onnx, scale_init=scale_init))
         self.add_module('up', UpBlock(out_spec, size=in_size))
         if crop is not None:
             self.add_module('crop', Crop(crop)) 

--- a/deepem/test/model.py
+++ b/deepem/test/model.py
@@ -51,8 +51,12 @@ class Model(nn.Module):
                 self.mask[k] = torch.from_numpy(mask).to(opt.device)
 
     def forward(self, sample):
-        inputs = [sample[k] for k in sorted(self.in_spec)]
-        preds = self.model(*inputs)
+        input_dict = {k: sample[k] for k in sorted(self.in_spec)}
+        if len(input_dict) == 1:
+            [input_tensor] = input_dict.values()
+            preds = self.model(input_tensor)
+        else:
+            preds = self.model(input_dict)
         outputs = dict()
         for k, x in preds.items():
             if k == 'embedding':

--- a/deepem/train/model.py
+++ b/deepem/train/model.py
@@ -21,13 +21,12 @@ class Model(nn.Module):
 
     def forward(self, sample):
         # Forward pass
-        inputs = [sample[k] for k in sorted(self.in_spec)]
-        # If multiple inputs, concatenate them
-        if len(inputs) > 1:
-            input_tensor = torch.cat(inputs, dim=1)
+        input_dict = {k: sample[k] for k in sorted(self.in_spec)}
+        if len(input_dict) == 1:
+            [input_tensor] = input_dict.values()
+            preds = self.model(input_tensor)
         else:
-            input_tensor = inputs[0]
-        preds = self.model(input_tensor)
+            preds = self.model(input_dict)
 
         # Loss evaluation
         try:

--- a/deepem/utils/onnx_utils.py
+++ b/deepem/utils/onnx_utils.py
@@ -32,14 +32,23 @@ def batchnorm3d_to_instancenorm3d(
 def dummy_input(
     spec: dict[str, tuple[int, ...]],
     device: str = 'cpu'
-) -> torch.Tensor:
-    """Generate a single random concatenated input tensor."""
+) -> torch.Tensor | tuple[torch.Tensor, ...]:
+    """Generate random input tensor(s).
+
+    Args:
+        spec: Dictionary mapping input names to their shapes
+        device: Device to create tensors on
+
+    Returns:
+        Single tensor for single input, tuple of tensors for multiple inputs
+    """
     tensors = []
     for k in sorted(spec):
         size = (1,) + tuple(spec[k])
         tensors.append(torch.randn(*size, device=device))
-    # Concatenate inputs along the channel dimension
-    return torch.cat(tensors, dim=1)
+
+    # Return single tensor for backwards compatibility if only one input
+    return tensors[0] if len(tensors) == 1 else tuple(tensors)
 
 
 def export_onnx(
@@ -73,17 +82,20 @@ def export_onnx(
 
     args = dummy_input(onnx_opt.in_spec, device=onnx_opt.device)
 
-    if torch.__version__ >= '1.10':
-        args = (args, {})
+    # For PyTorch >= 1.10, export() expects model_args and model_kwargs separately
+    export_args = (args, {}) if torch.__version__ >= '1.10' else args
+
+    # Generate input names based on spec keys
+    input_names = sorted(onnx_opt.in_spec.keys())
 
     torch.onnx.export(
         onnx_model,
-        args,
+        export_args,
         fname,
         verbose=False,
         export_params=True,
         opset_version=onnx_opt.opset_version,
-        input_names=["input"],  # single input tensor
+        input_names=input_names,  # dynamic input names based on spec
         output_names=["output"]
     )
     print(f"Relative ONNX filepath: {fname}")


### PR DESCRIPTION
This PR merges the `multi_io_dict` branch into `mito_to_cell`, refactoring multi-input neural network modules to handle inputs as dictionaries rather than concatenated tensors.

#### Key Changes:
- **Input Handling:** Models now accept multiple inputs via dictionaries, simplifying input management and improving clarity.
- **ONNX Compatibility:** Modified `InputBlock` classes to optionally support ONNX exports by accepting tuples ordered according to input specification keys.
- **Consistency in Forward Passes:** Adjusted `forward` methods across `test` and `train` model modules to consistently handle dictionary-based inputs.
- **Enhanced ONNX Utilities:** Updated `dummy_input` function to align with the new dictionary-based input approach, generating single tensors or tuples accordingly, and dynamically assigning input names during ONNX exports.

#### Benefits:
- Simplifies handling multiple inputs clearly and flexibly.
- Improves model interpretability and maintainability.
- Facilitates seamless ONNX model exports for deployment.
