### PR TITLE
feat(data): add support for combining multiple binary targets

### DIFF
--- a/deepem/data/dataset/multi_zettaset.py
+++ b/deepem/data/dataset/multi_zettaset.py
@@ -10,6 +10,26 @@ from zettasets.dataset import Dataset as Zettaset
 from zettasets.sample import Sample
 
 
+def parse_target_combination(target_spec: str) -> list[str]:
+    """
+    Parse a target specification that may contain combinations.
+
+    Examples:
+        "mye" -> ["mye"]
+        "mye + ecs" -> ["mye", "ecs"]
+        "a+b+c" -> ["a", "b", "c"]
+
+    Args:
+        target_spec: Target specification string
+
+    Returns:
+        List of individual target keys
+    """
+    # Split by '+' and strip whitespace
+    targets = [t.strip() for t in target_spec.split('+')]
+    return targets
+
+
 def is_valid_format(s: str) -> bool:
     """Check if string has format 'A:B'."""
     return bool(re.match(r'^[^:]+:[^:]+$', s))
@@ -184,28 +204,53 @@ def load_sample(
         shared_mask = convert_array(mask_vol).astype("uint8")
 
     # Process annotations
-    for name, key in zettaset_lookup.items():
+    for name, key_spec in zettaset_lookup.items():
 
-        # Annotation
-        vol = sample.read(key)[key]
-        dset[name] = convert_array(vol)
-        anno_log = f"\t{name}: {dset[name].shape}"
+        # Parse target combination (e.g., "mye + ecs" -> ["mye", "ecs"])
+        target_keys = parse_target_combination(key_spec)
 
-        # Semantic mapping or binarize
-        if name in semantic_mapping:
-            dset[name] = (dset[name] == semantic_mapping[name]).astype("uint8")
-        elif name in requires_binarize:
-            dset[name] = (dset[name] > 0).astype("uint8")
+        # Load and combine targets
+        combined_data = None
+        combined_mask = None
 
-        # Mask
+        for key in target_keys:
+            # Annotation
+            vol = sample.read(key)[key]
+            data_array = convert_array(vol)
+
+            # Semantic mapping or binarize (before combining)
+            if name in semantic_mapping:
+                data_array = (data_array == semantic_mapping[name]).astype("uint8")
+            elif name in requires_binarize:
+                data_array = (data_array > 0).astype("uint8")
+
+            # Combine (logical OR for binary targets)
+            if combined_data is None:
+                combined_data = data_array
+            else:
+                combined_data = np.maximum(combined_data, data_array)
+
+            # Mask
+            mask_key = f"{name}_mask"
+            if shared_mask is not None:
+                mask_array = shared_mask
+            elif (not no_mask) and (key in sample.masks):
+                mask_vol = sample.read_mask(key)[key]
+                mask_array = convert_array(mask_vol).astype("uint8")
+            else:
+                mask_array = np.ones_like(data_array, dtype="uint8")
+
+            # Combine masks (logical OR)
+            if combined_mask is None:
+                combined_mask = mask_array
+            else:
+                combined_mask = np.maximum(combined_mask, mask_array)
+
+        dset[name] = combined_data
+        anno_log = f"\t{name}: {dset[name].shape} (combined from {target_keys})"
+
         mask_key = f"{name}_mask"
-        if shared_mask is not None:
-            dset[mask_key] = shared_mask
-        elif (not no_mask) and (key in sample.masks):
-            mask_vol = sample.read_mask(key)[key]
-            dset[mask_key] = convert_array(mask_vol).astype("uint8")
-        else:
-            dset[mask_key] = np.ones_like(dset[name], dtype="uint8")
+        dset[mask_key] = combined_mask
         msk_log = f"\t{mask_key}: {dset[mask_key].shape}"
 
         # Padding

--- a/deepem/data/dataset/zettaset.py
+++ b/deepem/data/dataset/zettaset.py
@@ -3,9 +3,30 @@ from __future__ import annotations
 from cloudvolume import CloudVolume, Bbox
 import numpy as np
 from numpy.typing import ArrayLike
+import re
 
 from zettasets.dataset import Dataset as Zettaset
 from zettasets.sample import Sample
+
+
+def parse_target_combination(target_spec: str) -> list[str]:
+    """
+    Parse a target specification that may contain combinations.
+
+    Examples:
+        "mye" -> ["mye"]
+        "mye + ecs" -> ["mye", "ecs"]
+        "a+b+c" -> ["a", "b", "c"]
+
+    Args:
+        target_spec: Target specification string
+
+    Returns:
+        List of individual target keys
+    """
+    # Split by '+' and strip whitespace
+    targets = [t.strip() for t in target_spec.split('+')]
+    return targets
 
 
 def load_data(
@@ -85,23 +106,47 @@ def load_sample(
         zettaset_lookup = {x: x for x in sample.annotation_names}
 
     # Annotations
-    for name, key in zettaset_lookup.items():
+    for name, key_spec in zettaset_lookup.items():
 
-        # Annotation
-        vol = sample.read(key)[key]
-        dset[name] = convert_array(vol)
-        print(f"{name}: {dset[name].shape}")
+        # Parse target combination (e.g., "mye + ecs" -> ["mye", "ecs"])
+        target_keys = parse_target_combination(key_spec)
 
-        # Binarize
-        if name in requires_binarize:
-            dset[name] = (dset[name] > 0).astype('uint8')
+        # Load and combine targets
+        combined_data = None
+        combined_mask = None
 
-        # Mask
-        if zettaset_mask and (key in sample.masks):
-            vol = sample.read_mask(key)[key]
-            dset[name + "_mask"] = convert_array(vol).astype('uint8')
-        else:
-            dset[name + "_mask"] = np.ones_like(dset[name], dtype='uint8')
+        for key in target_keys:
+            # Annotation
+            vol = sample.read(key)[key]
+            data_array = convert_array(vol)
+
+            # Binarize if needed (before combining)
+            if name in requires_binarize:
+                data_array = (data_array > 0).astype('uint8')
+
+            # Combine (logical OR for binary targets)
+            if combined_data is None:
+                combined_data = data_array
+            else:
+                combined_data = np.maximum(combined_data, data_array)
+
+            # Mask
+            if zettaset_mask and (key in sample.masks):
+                vol = sample.read_mask(key)[key]
+                mask_array = convert_array(vol).astype('uint8')
+            else:
+                mask_array = np.ones_like(data_array, dtype='uint8')
+
+            # Combine masks (logical OR)
+            if combined_mask is None:
+                combined_mask = mask_array
+            else:
+                combined_mask = np.maximum(combined_mask, mask_array)
+
+        dset[name] = combined_data
+        print(f"{name}: {dset[name].shape} (combined from {target_keys})")
+
+        dset[name + "_mask"] = combined_mask
         print(f"{name + '_mask'}: {dset[name + '_mask'].shape}")
 
         # applying padding

--- a/test_target_combination.py
+++ b/test_target_combination.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+"""Test script for target combination feature."""
+
+import sys
+import os
+
+# Add the deepem module to the path
+sys.path.insert(0, os.path.dirname(__file__))
+
+from deepem.data.dataset.zettaset import parse_target_combination
+from deepem.data.dataset.multi_zettaset import parse_target_combination as parse_target_combination_multi
+
+def test_parse_target_combination():
+    """Test the parse_target_combination function."""
+
+    # Test single target
+    result = parse_target_combination("mye")
+    assert result == ["mye"], f"Expected ['mye'], got {result}"
+    print("✓ Single target: 'mye' -> ['mye']")
+
+    # Test two targets with spaces
+    result = parse_target_combination("mye + ecs")
+    assert result == ["mye", "ecs"], f"Expected ['mye', 'ecs'], got {result}"
+    print("✓ Two targets with spaces: 'mye + ecs' -> ['mye', 'ecs']")
+
+    # Test two targets without spaces
+    result = parse_target_combination("mye+ecs")
+    assert result == ["mye", "ecs"], f"Expected ['mye', 'ecs'], got {result}"
+    print("✓ Two targets without spaces: 'mye+ecs' -> ['mye', 'ecs']")
+
+    # Test three targets
+    result = parse_target_combination("a + b + c")
+    assert result == ["a", "b", "c"], f"Expected ['a', 'b', 'c'], got {result}"
+    print("✓ Three targets: 'a + b + c' -> ['a', 'b', 'c']")
+
+    # Test with extra whitespace
+    result = parse_target_combination("  mye  +  ecs  ")
+    assert result == ["mye", "ecs"], f"Expected ['mye', 'ecs'], got {result}"
+    print("✓ Extra whitespace: '  mye  +  ecs  ' -> ['mye', 'ecs']")
+
+    # Verify multi_zettaset has the same function
+    result = parse_target_combination_multi("mye + ecs")
+    assert result == ["mye", "ecs"], f"Expected ['mye', 'ecs'], got {result}"
+    print("✓ multi_zettaset.parse_target_combination works correctly")
+
+    print("\n✅ All tests passed!")
+
+if __name__ == "__main__":
+    test_parse_target_combination()


### PR DESCRIPTION
This feature allows users to combine multiple binary targets using the '+' operator in zettaset_lookup configuration. For example:
  "zettaset_lookup": {"myelin": "mye + ecs"}

Changes:
- Added parse_target_combination() function to parse target combination syntax
- Modified load_sample() in both zettaset.py and multi_zettaset.py to:
  * Load multiple targets when combination syntax is detected
  * Combine target data using logical OR (np.maximum)
  * Combine masks using logical OR
- Added test_target_combination.py to verify parsing functionality

Usage examples:
  - Single target: "myelin": "mye" -> loads "mye"
  - Combined targets: "myelin": "mye + ecs" -> loads and combines "mye" and "ecs"
  - Multiple targets: "cell": "a + b + c" -> loads and combines all three

🤖 Generated with [Claude Code](https://claude.com/claude-code)