### PR TITLE
feat(data): support excluding samples from train_ids

### DIFF
--- a/deepem/train/option.py
+++ b/deepem/train/option.py
@@ -31,6 +31,26 @@ def parse_class_weight(value):
         return float(value)
 
 
+def _parse_exclusions(ids):
+    """Parse ^-prefixed exclusion entries from a list of IDs.
+
+    Args:
+        ids: List of data IDs, where ^-prefixed entries are exclusions.
+            e.g., ["hemibrain", "^hemibrain:lobula", "cerebellum:vol001"]
+
+    Returns:
+        (include_ids, exclude_ids): Two lists with the ^ prefix stripped.
+    """
+    include_ids = []
+    exclude_ids = []
+    for x in ids:
+        if x.startswith('^'):
+            exclude_ids.append(x[1:])
+        else:
+            include_ids.append(x)
+    return include_ids, exclude_ids
+
+
 class Options(object):
     """
     Training options.
@@ -70,6 +90,8 @@ class Options(object):
         self.parser.add_argument('--train_prob', type=float, default=None, nargs='+')
         self.parser.add_argument('--val_ids', type=str, default=[], nargs='+')
         self.parser.add_argument('--val_prob', type=float, default=None, nargs='+')
+        self.parser.add_argument('--exclude_val', action='store_true',
+                                 help='Exclude val_ids from train_ids (for superset overlap)')
 
         # Training
         self.parser.add_argument('--max_iter', type=int, default=1000000)
@@ -246,7 +268,8 @@ class Options(object):
         if opt.samwise_map is not None:
             opt.samwise_map = samwise.parse.parsemap(opt.samwise_map)
 
-        # Training/validation sets
+        # Training/validation sets: parse ^exclusions from train_ids
+        opt.train_ids, opt.train_exclude = _parse_exclusions(opt.train_ids)
         if (not opt.train_ids) or (not opt.val_ids):
             raise ValueError("Train/validation IDs unspecified")
         if opt.train_prob:

--- a/deepem/train/utils.py
+++ b/deepem/train/utils.py
@@ -221,10 +221,17 @@ def load_data(opt, local_rank):
         **opt.data_params
     )
 
-    # Train
-    train_data = {k: data[k] for k in opt.train_ids}
+    # Train (with exclusion filtering)
+    exclude_ids = list(opt.train_exclude)
+    if opt.exclude_val:
+        exclude_ids.extend(opt.val_ids)
+    train_data, excluded_ids = _filter_train_data(
+        data, opt.train_ids, exclude_ids, opt.zettaset_specs
+    )
     if opt.train_prob:
         prob = dict(zip(opt.train_ids, opt.train_prob))
+        # Drop prob entries for fully-excluded train_ids
+        prob = {k: v for k, v in prob.items() if k in train_data}
     else:
         prob = None
     train_loader = Data(opt, train_data, is_train=True, prob=prob, local_rank=local_rank)
@@ -238,6 +245,69 @@ def load_data(opt, local_rank):
     val_loader = Data(opt, val_data, is_train=False, prob=prob, local_rank=local_rank)
 
     return train_loader, val_loader
+
+
+def _filter_train_data(data, train_ids, exclude_ids, zettaset_specs):
+    """Filter excluded sample IDs out of training data.
+
+    Handles both superset and sample-level exclusions:
+    - ^hemibrain:lobula  -> removes that sample from the hemibrain superset
+    - ^hemibrain         -> expands to all samples, removes them all
+
+    Args:
+        data: Loaded data dict from multi_zettaset.load_data.
+        train_ids: List of training data IDs (inclusions only).
+        exclude_ids: List of IDs to exclude (^ prefix already stripped).
+        zettaset_specs: Zettaset specifications dict (may be empty/None).
+
+    Returns:
+        (filtered_data, excluded_samples): Filtered training data dict and
+            the set of sample IDs that were actually excluded.
+    """
+    if not exclude_ids:
+        return {k: data[k] for k in train_ids}, set()
+
+    zettaset_specs = zettaset_specs or {}
+
+    # Expand superset exclusions to sample-level
+    expanded_excludes = set()
+    for eid in exclude_ids:
+        if eid in zettaset_specs and eid in data and isinstance(data[eid], dict):
+            # Superset exclusion -> expand to all its samples
+            expanded_excludes.update(data[eid].keys())
+        else:
+            expanded_excludes.add(eid)
+
+    # Filter train data
+    result = {}
+    excluded_samples = set()
+    for k in train_ids:
+        if k in zettaset_specs and isinstance(data.get(k), dict):
+            # Superset: filter out excluded children
+            original = data[k]
+            filtered = {sk: sv for sk, sv in original.items()
+                        if sk not in expanded_excludes}
+            newly_excluded = set(original.keys()) - set(filtered.keys())
+            if newly_excluded:
+                excluded_samples.update(newly_excluded)
+                print(f"Excluded from '{k}': {sorted(newly_excluded)}")
+            if filtered:
+                result[k] = filtered
+                print(f"Remaining in '{k}': {sorted(filtered.keys())}")
+            else:
+                print(f"WARNING: All samples excluded from superset '{k}'")
+        else:
+            # Sample ID: skip if excluded
+            if k in expanded_excludes:
+                excluded_samples.add(k)
+                print(f"Excluded: {k}")
+            else:
+                result[k] = data[k]
+
+    if excluded_samples:
+        print(f"Total excluded from training: {len(excluded_samples)} sample(s)")
+
+    return result, excluded_samples
 
 
 def forward(model, sample, opt):


### PR DESCRIPTION
## Summary
- Add `^` exclusion syntax in `--train_ids` to remove specific samples from supersets (e.g., `--train_ids hemibrain ^hemibrain:lobula`)
- Add `--exclude_val` flag to automatically exclude `val_ids` from `train_ids` (for superset overlap)
- Sampling probabilities auto-adjust via DataProvider's `num_samples()`-based weighting

## Usage
```
# Inline ^ syntax
--train_ids hemibrain ^hemibrain:lobula --val_ids hemibrain:lobula

# Or opt-in val exclusion
--train_ids hemibrain --val_ids hemibrain:lobula --exclude_val
```

## Test plan
- [x] Local test with `--exclude_val` flag (hemibrain superset, lobula excluded)
- [x] Local test with `^` syntax (`hemibrain ^hemibrain:lobula`)
- [x] Verified "Excluded from" and "Remaining in" log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)